### PR TITLE
Reduce some repetitive operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ include = ["src/*.rs", "tests/*.rs", "examples/*.rs", "Cargo.toml"]
 readme = "README.md"
 
 [dependencies]
+lazy_static = "1"
 regex = "0.2"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,25 +14,14 @@ pub fn matcher<'a>(pattern: &'a str, url: &'a str) -> Option<HashMap<String, &'a
     let expr = util::expression(pattern);
     let re = util::regexp(&expr);
 
-    if re.is_match(url) {
+    let caps = re.captures(url)?;
 
-        let caps = re.captures(url).unwrap();
-
-        for (index, key) in re.capture_names().enumerate() {
-
-            if key.is_some() {
-                let k = String::from(key.unwrap());
-                let v = caps.get(index).unwrap().as_str();
-
-                map.insert(k, v);
-
-            }
-
+    for (index, key) in re.capture_names().enumerate() {
+        if let (Some(k), Some(c)) = (key, caps.get(index)) {
+            map.insert(k.to_owned(), c.as_str());
         }
-        
-        Some(map)
-    } else {
-        None
     }
+
+    Some(map)
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
+#[macro_use]
+extern crate lazy_static;
+
 extern crate regex;
+
 use std::collections::HashMap;
 
 mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,19 +1,23 @@
 use regex::Regex;
 
 pub fn escape(pattern : &str) -> String {
+    lazy_static! {
+        static ref KEY: Regex = Regex::new(r"(?P<key>[?&.])").unwrap();
+    }
 
-    let exp = String::from(Regex::new(r"(?P<key>[?&.])").unwrap().replace_all(pattern, r"\$key"));
+    let exp = String::from(KEY.replace_all(pattern, r"\$key"));
 
     exp
 }
 
 pub fn expression(pattern : &str) -> String {
-
-    let chars = Regex::new(r":(?P<key>[a-zA-Z0-9_-]+)").unwrap();
+    lazy_static! {
+        static ref CHARS: Regex = Regex::new(r":(?P<key>[a-zA-Z0-9_-]+)").unwrap();
+    }
 
     let mut exp = String::from(r"^");
 
-    exp.push_str(&chars.replace_all( &escape(pattern), r"(?P<$key>[a-zA-Z0-9_-]+)"));
+    exp.push_str(&CHARS.replace_all( &escape(pattern), r"(?P<$key>[a-zA-Z0-9_-]+)"));
     exp.push_str("$");
     
     exp


### PR DESCRIPTION
Following [the suggestion][1], regular expressions can be compiled only once and be reused using [lazy_static][], instead of recompiling it every function call.

[1]: https://docs.rs/regex/0.2.10/regex/index.html#example-avoid-compiling-the-same-regex-in-a-loop
[lazy_static]: https://github.com/rust-lang-nursery/lazy-static.rs